### PR TITLE
Add Google Analytics to blog

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-148336929-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-148336929-1');
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,12 @@
     <![endif]-->
 
     <title> {{ page.title }} </title>
+
+    <!-- Add Google Analytics  -->
+    {% if jekyll.environment == 'production' %}
+    {% include analytics.html %}
+    {% endif %}
+
   </head>
 
   <body>


### PR DESCRIPTION
This commit should enable Google Analytics for the blog, using [these instructions](https://michaelsoolee.com/google-analytics-jekyll/).

Make sure if works before merging.